### PR TITLE
Add Reactadelphia to streamers list under new event heading

### DIFF
--- a/docs/list-of-streamers.md
+++ b/docs/list-of-streamers.md
@@ -21,3 +21,7 @@ https://www.twitch.tv/roberttables
 https://mixer.com/juicetrades
 
 https://mixer.com/ryanharris
+
+### Events / Organizations
+
+https://www.twitch.tv/reactadelphia/


### PR DESCRIPTION
Changes:
1. Added a new heading for `Events / Organizations`
2. Added Reactadelphia's Twitch account under the new heading

**Before**
<img width="616" alt="image" src="https://user-images.githubusercontent.com/4997781/69206720-6c774600-0b1b-11ea-92e5-4304c23519b8.png">

**After**
<img width="620" alt="image" src="https://user-images.githubusercontent.com/4997781/69206699-61bcb100-0b1b-11ea-969a-5820ea882cf2.png">
