### PR TITLE
Add rheinardkorf to Mixer list

### DIFF
--- a/docs/list-of-streamers.md
+++ b/docs/list-of-streamers.md
@@ -12,10 +12,10 @@
 - https://www.twitch.tv/ipwnpancakes
 - https://www.twitch.tv/rahatcodes
 
-
 ### Mixer
 
 - https://mixer.com/juicetrades
+- https://mixer.com/rheinardkorf
 - https://mixer.com/ryanharris
 - https://mixer.com/ncphi
 


### PR DESCRIPTION
## Notes
This PR adds Rheinhard Korf to the streamers list under the Mixer section 🚀

**After**
<img width="385" alt="image" src="https://user-images.githubusercontent.com/4997781/69730471-22cbc400-10f6-11ea-8397-944fdfbf9718.png">
