### PR TITLE
feature: adds focus selectors to match hover styles

### DIFF
--- a/packages/www/src/components/Button.js
+++ b/packages/www/src/components/Button.js
@@ -15,7 +15,7 @@ export const buttonStyles = {
   textDecoration: 'none',
   fontWeight: 'heading',
 
-  '&:hover': {
+  '&:hover, &:focus': {
     backgroundColor: 'background'
   }
 }

--- a/packages/www/src/components/Nav.js
+++ b/packages/www/src/components/Nav.js
@@ -36,7 +36,7 @@ const Nav = ({ data, location }) => {
               backgroundColor: location.pathname === item.url ? 'blackTransparent' : 'none',
               color: location.pathname === item.url ? item.color : 'white',
 
-              '&:hover': {
+              '&:hover, &:focus': {
                 backgroundColor: 'blackTransparent',
                 color: item.color
               }
@@ -50,7 +50,7 @@ const Nav = ({ data, location }) => {
           sx={{
             ...navItemStyles,
 
-            '&:hover': {
+            '&:hover, &:focus': {
               backgroundColor: 'blackTransparent',
               color: 'blue'
             }

--- a/packages/www/src/gatsby-plugin-theme-ui/index.js
+++ b/packages/www/src/gatsby-plugin-theme-ui/index.js
@@ -52,7 +52,7 @@ export default {
         textDecorationColor: '#EA6AFF',
         transition: 'color 175ms ease-out',
 
-        '&:hover': {
+        '&:hover, &:focus': {
           color: 'blue'
         }
       },


### PR DESCRIPTION
To help improve keyboard experience, I've added '&:focus' to match hover styles for keyboard navigation. 

We will still to improve focus styles in the body to match [WCAG 2.2 guidelines](https://w3c.github.io/wcag/guidelines/22/#focus-visible-enhanced). 