### PR TITLE
Fixed horizontal scroll bug

### DIFF
--- a/packages/www/src/components/Hero.js
+++ b/packages/www/src/components/Hero.js
@@ -17,7 +17,7 @@ const Hero = data => {
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
-        width: '100vw',
+        width: '100%',
         height: ['auto', '684px'],
         padding: ['80px 0', 0],
         position: 'relative',

--- a/packages/www/src/components/PageTemplate.js
+++ b/packages/www/src/components/PageTemplate.js
@@ -15,7 +15,7 @@ export default ({ title, children }) => (
   >
     <div
       sx={{
-        width: '100vw',
+        width: '100%',
         height: ['220px', '336px'],
         top: 0,
         left: 0,


### PR DESCRIPTION
The various pages had bug where the top gradient was extending to be beyond the wanted width so it added a horizontal scroll on desktop.

This PR fixes that by changing the width of that gradient container both in the `PageTemplate` and `Hero` components to be `100%` instead of `100vw`.