### PR TITLE
feat: add focus styles to selectable elements

### DIFF
--- a/packages/www/src/components/Button.js
+++ b/packages/www/src/components/Button.js
@@ -16,8 +16,12 @@ export const buttonStyles = {
   fontWeight: 'heading',
 
   '&:hover, &:focus': {
-    backgroundColor: 'background'
-  }
+    backgroundColor: 'background',
+  },
+  '&:focus': {
+    outline: '0',
+    boxShadow: '0 0 0 3pt #9668cc',
+  },
 }
 
 export default ({ children }) => <button sx={buttonStyles}>{children}</button>

--- a/packages/www/src/components/Hero.js
+++ b/packages/www/src/components/Hero.js
@@ -21,7 +21,8 @@ const Hero = data => {
         height: ['auto', '684px'],
         padding: ['80px 0', 0],
         position: 'relative',
-        background: 'linear-gradient(164.92deg, #9B6BD3 12.72%, #00E992 84.21%)'
+        background:
+          'linear-gradient(164.92deg, #9B6BD3 12.72%, #00E992 84.21%)',
       }}
     >
       <MaxWidth
@@ -29,7 +30,7 @@ const Hero = data => {
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          width: '100%'
+          width: '100%',
         }}
       >
         <h1
@@ -38,16 +39,14 @@ const Hero = data => {
             marginBottom: '54px',
             maxWidth: '860px',
             textAlign: 'center',
-            color: 'purple10'
+            color: 'purple10',
           }}
         >
           {description}
         </h1>
         <a href={discordInviteUrl} target='_blank' sx={buttonStyles}>
           <Discord />
-          <span sx={{ marginLeft: '10px' }}>
-            Join Discord
-          </span>
+          <span sx={{ marginLeft: '10px' }}>Join Discord</span>
         </a>
       </MaxWidth>
     </section>

--- a/packages/www/src/components/Logo.js
+++ b/packages/www/src/components/Logo.js
@@ -5,7 +5,7 @@ import { Link } from 'gatsby'
 import PartyCorgi from './PartyCorgi'
 import Wordmark from './Wordmark'
 
-export default ({ children }) =>
+export default ({ children }) => (
   <Link
     sx={{
       fontSize: 'navItem',
@@ -16,16 +16,21 @@ export default ({ children }) =>
 
       '&:hover': {
         '.corgiAnimated': {
-          opacity: 1
+          opacity: 1,
         },
 
         '.corgiStill': {
-          opacity: 0
-        }
-      }
+          opacity: 0,
+        },
+      },
+      '&:focus': {
+        outline: '0',
+        boxShadow: '0 0 0 2pt #62BFF2',
+      },
     }}
     to='/'
   >
     <PartyCorgi />
     <Wordmark />
   </Link>
+)

--- a/packages/www/src/components/Nav.js
+++ b/packages/www/src/components/Nav.js
@@ -33,13 +33,18 @@ const Nav = ({ data, location }) => {
             to={item.url}
             sx={{
               ...navItemStyles,
-              backgroundColor: location.pathname === item.url ? 'blackTransparent' : 'none',
+              backgroundColor:
+                location.pathname === item.url ? 'blackTransparent' : 'none',
               color: location.pathname === item.url ? item.color : 'white',
 
               '&:hover, &:focus': {
                 backgroundColor: 'blackTransparent',
-                color: item.color
-              }
+                color: item.color,
+              },
+              '&:focus': {
+                outline: '0',
+                boxShadow: `0 0 0 2pt ${item.color}`,
+              },
             }}
           >
             {item.display}
@@ -52,8 +57,12 @@ const Nav = ({ data, location }) => {
 
             '&:hover, &:focus': {
               backgroundColor: 'blackTransparent',
-              color: 'blue'
-            }
+              color: 'blue',
+            },
+            '&:focus': {
+              outline: '0',
+              boxShadow: '0 0 0 2pt blue',
+            },
           }}
         >
           Join Discord
@@ -74,4 +83,9 @@ const query = graphql`
   }
 `
 
-export default props => <StaticQuery query={query} render={(data) => <Nav data={data} location={props.location} />} />
+export default props => (
+  <StaticQuery
+    query={query}
+    render={data => <Nav data={data} location={props.location} />}
+  />
+)

--- a/packages/www/src/components/Stickers.js
+++ b/packages/www/src/components/Stickers.js
@@ -18,7 +18,7 @@ export default () => {
       'pk_test_38mtS6edMLcrnhLxmoAbTa1S00zC8bvrmi'
     )
     const { error } = await stripe.redirectToCheckout({
-      sessionId: data.sessionId
+      sessionId: data.sessionId,
     })
 
     alert(error.message)
@@ -27,7 +27,7 @@ export default () => {
   return (
     <section
       sx={{
-        marginBottom: '50px'
+        marginBottom: '50px',
       }}
     >
       <CapsTitle>Stickers</CapsTitle>
@@ -36,7 +36,9 @@ export default () => {
         method='POST'
         onSubmit={handleSubmit}
       >
-        <button type='submit'>Buy Stickers</button>
+        <button type='submit' sx={{ '&:focus': { outline: 'solid #9668cc' } }}>
+          Buy Stickers
+        </button>
       </form>
       <p>This is currently a test — it doesn’t work yet!</p>
     </section>

--- a/packages/www/src/components/TankTop/index.js
+++ b/packages/www/src/components/TankTop/index.js
@@ -12,7 +12,7 @@ const tankTopUrl = 'https://store.egghead.io/product/party-corgi-tank-top'
 export default () => {
   return (
     <section sx={{
-      marginBottom: '50px'
+      marginBottom: '50px',
     }}>
       <CapsTitle>
         Party Corgi Tank Top
@@ -25,6 +25,9 @@ export default () => {
             'svg': {
               transform: 'scale3d(1.3, 1.3, 1.3) rotate(6deg)'
             }
+          },
+          '&:focus': {
+            outline: 'solid white'
           }
         }}
       >


### PR DESCRIPTION
Begins to address #35 

I took a shot at adding focus styles to selectable elements. Got through the items on the home page, but ran into some trouble trying to target links on the "Streamers" and "Code of Conduct" pages, because they're in `<MDXDocument />`.

It's likely I just don't fully understand how to target those elements, any advice on how to do that would definitely be appreciated.

Ideally it would be best to establish outline styles in the theme, but I think this should work for now.